### PR TITLE
magisk: add option to reset /data/adb when there are boot issues

### DIFF
--- a/native/jni/core/bootstages.cpp
+++ b/native/jni/core/bootstages.cpp
@@ -476,6 +476,14 @@ void remove_modules() {
 	reboot();
 }
 
+void remove_magiskdata() {
+	LOGI("* Remove all Magisk data and reboot");
+	chdir(SECURE_DIR);
+	rm_rf("./*");
+	chdir("/");
+	reboot();
+}
+
 static void collect_modules() {
 	chdir(MODULEROOT);
 	rm_rf("lost+found");

--- a/native/jni/core/daemon.cpp
+++ b/native/jni/core/daemon.cpp
@@ -91,6 +91,15 @@ static void *request_handler(void *args) {
 		}
 		close(client);
 		break;
+	case REMOVE_MAGISKDATA:
+		if (credential.uid == UID_SHELL || credential.uid == UID_ROOT) {
+			remove_magiskdata();
+			write_int(client, 0);
+		} else {
+			write_int(client, 1);
+		}
+		close(client);
+		break;
 	default:
 		close(client);
 		break;

--- a/native/jni/core/magisk.cpp
+++ b/native/jni/core/magisk.cpp
@@ -27,6 +27,7 @@ Options:
    --list                    list all available applets
    --daemon                  manually start magisk daemon
    --remove-modules          remove all modules and reboot
+   --remove-magisk-data      remove all Magisk data and reboot
    --[init trigger]          start service for init trigger
 
 Advanced Options (Internal APIs):
@@ -114,6 +115,10 @@ int magisk_main(int argc, char *argv[]) {
 	} else if (argv[1] == "--remove-modules"sv) {
 		int fd = connect_daemon();
 		write_int(fd, REMOVE_MODULES);
+		return read_int(fd);
+	} else if (argv[1] == "--remove-magisk-data"sv) {
+		int fd = connect_daemon();
+		write_int(fd, REMOVE_MAGISKDATA);
 		return read_int(fd);
 	}
 #if 0


### PR DESCRIPTION
- where --remove-modules may not be sufficient, --remove-magisk-data may, for example with the current issue introduced in 20105 where the broken magisk.db will soft-brick a device without Magisk Manager installed until /data/adb/* is removed